### PR TITLE
Feature/region field

### DIFF
--- a/dist/edge-locations.csv
+++ b/dist/edge-locations.csv
@@ -1,74 +1,74 @@
-code,city,state,country,count,latitude,longitude
-IAD,Ashburn,Virginia,United States,6,38.9445,-77.4558029
-ATL,Atlanta,Georgia,United States,5,33.6367,-84.428101
-BOS,Boston,Massachusetts,United States,3,42.36429977,-71.00520325
-ORD,Chicago,Illinois,United States,7,41.978611,-87.904722
-DFW,Dallas/Fort Worth,Texas,United States,6,32.896801,-97.038002
-DEN,Denver,Colorado,United States,2,39.861698150635,-104.672996521
-HWD,Hayward,California,United States,1,37.658889,-122.121667
-HIO,Hillsboro,Oregon,United States,2,45.540394,-122.949825
-HOU,Houston,Texas,United States,4,29.64539909,-95.27890015
-JAX,Jacksonville,Florida,United States,1,30.49410057067871,-81.68789672851562
-LAX,Los Angeles,California,United States,5,33.94250107,-118.4079971
-MIA,Miami,Florida,United States,3,25.79319953918457,-80.29060363769531
-MSP,Minneapolis,Minnesota,United States,1,44.882,-93.221802
-YUL,Montreal,Quebec,Canada,1,45.470556,-73.740833
-JFK,New York,New York,United States,3,40.63980103,-73.77890015
-EWR,Newark,New Jersey,United States,5,40.692501068115234,-74.168701171875
-PAO,Palo Alto,California,United States,1,37.461111,-122.115
-PHL,Philadelphia,Pennsylvania,United States,1,39.87189865112305,-75.24109649658203
-PHX,Phoenix,Arizona,United States,2,33.43429946899414,-112.01200103759766
-SLC,Salt Lake City,Utah,United States,1,40.78839874267578,-111.97799682617188
-SJC,San Jose,California,United States,2,37.362598,-121.929001
-SEA,Seattle,Washington,United States,4,47.448889,-122.309444
-IND,South Bend,Indiana,United States,1,39.7173004,-86.2944031
-YTO,Toronto,Ontario,Canada,2,43.6772003174,-79.63059997559999
-AMS,Amsterdam,,The Netherlands,2,52.308601,4.76389
-TXL,Berlin,,Germany,2,52.559722,13.287778
-CPH,Copenhagen,,Denmark,1,55.617900848389,12.656000137329
-DUB,Dublin,,Ireland,1,53.421299,-6.27007
-FRA,Frankfurt am Main,,Germany,8,50.033333,8.570556
-HEL,Helsinki,,Finland,1,60.317199707031,24.963300704956
-LIS,Lisbon,,Portugal,1,38.7813,-9.13592
-LHR,London,,England,9,51.4775,-0.461389
-MAD,Madrid,,Spain,2,40.471926,-3.56264
-MAN,Manchester,,England,2,53.35369873046875,-2.2749500274658203
-MRS,Marseille,,France,1,43.439271922,5.22142410278
-MXP,Milan,,Italy,1,45.6306,8.72811
-MUC,Munich,,Germany,2,48.353802,11.7861
-OSL,Oslo,,Norway,1,60.193901062012,11.100399971008
-PMO,Palermo,,Italy,1,38.175999,13.091
-CDG,Paris,,France,5,49.012798,2.55
-PRG,Prague,,Czech Republic,1,50.1008,14.26
-ARN,Stockholm,,Sweden,3,59.651901245117,17.918600082397
-VIE,Vienna,,Austria,1,48.110298156738,16.569700241089
-WMI,Warsaw,,Poland,1,52.451099,20.6518
-ZRH,Zurich,,Switzerland,2,47.464699,8.54917
-BLR,Bangalore,,India,3,13.1979,77.706299
-MAA,Chennai,,India,2,12.990005493164062,80.16929626464844
-HKG,Hong Kong,,China,3,22.308901,113.915001
-HYD,Hyderabad,,India,4,17.2313175201,78.4298553467
-KUL,Kuala Lumpur,,Malaysia,1,2.745579957962,101.70999908447
-BOM,Mumbai,,India,2,19.0886993408,72.8678970337
-MNL,Manila,,Philippines,1,14.5086,121.019997
-DEL,New Delhi,,India,5,28.5665,77.103104
-KIX,Osaka,,Japan,1,34.42729949951172,135.24400329589844
-ICN,Seoul,,South Korea,4,37.46910095214844,126.45099639892578
-SIN,Singapore,,Singapore,3,1.35019,103.994003
-TPE,Taipei,,Taiwan,3,25.0777,121.233002
-NRT,Tokyo,,Japan,12,35.7647018433,140.386001587
-MEL,Melbourne,,Australia,1,-37.673302,144.843002
-PER,Perth,,Australia,1,-31.94029998779297,115.96700286865234
-SYD,Sydney,,Australia,2,-33.94609832763672,151.177001953125
-GRU,Sao Paulo,,Brazil,2,-23.435556,-46.473056
-GIG,Rio de Janeiro,,Brazil,3,-22.8099994659,-43.2505569458
-DXB,Dubai,,United Arab Emirates,1,25.2527999878,55.3643989563
-FJR,Fujairah,,United Arab Emirates,1,25.112222,56.324167
-BAH,Manama,,Bahrain,1,26.27079963684082,50.63359832763672
-TLV,Tel Aviv,,Israel,1,32.01139831542969,34.88669967651367
-JNB,Johannesburg,,South Africa,1,-26.1392,28.246
-CPT,Cape Town,,South Africa,1,-33.9648017883,18.6016998291
-PEK,Beijing,,China,1,40.080101013183594,116.58499908447266
-SZX,Shenzhen,,China,1,22.639299392700195,113.81099700927734
-PVG,Shanghai,,China,1,31.143400192260742,121.80500030517578
-ZHY,Zhongwei,,China,1,37.572778,105.154444
+code,city,state,country,count,latitude,longitude,region
+IAD,Ashburn,Virginia,United States,6,38.9445,-77.4558029,North America
+ATL,Atlanta,Georgia,United States,5,33.6367,-84.428101,North America
+BOS,Boston,Massachusetts,United States,3,42.36429977,-71.00520325,North America
+ORD,Chicago,Illinois,United States,7,41.978611,-87.904722,North America
+DFW,Dallas/Fort Worth,Texas,United States,6,32.896801,-97.038002,North America
+DEN,Denver,Colorado,United States,2,39.861698150635,-104.672996521,North America
+HWD,Hayward,California,United States,1,37.658889,-122.121667,North America
+HIO,Hillsboro,Oregon,United States,2,45.540394,-122.949825,North America
+HOU,Houston,Texas,United States,4,29.64539909,-95.27890015,North America
+JAX,Jacksonville,Florida,United States,1,30.49410057067871,-81.68789672851562,North America
+LAX,Los Angeles,California,United States,5,33.94250107,-118.4079971,North America
+MIA,Miami,Florida,United States,3,25.79319953918457,-80.29060363769531,North America
+MSP,Minneapolis,Minnesota,United States,1,44.882,-93.221802,North America
+YUL,Montreal,Quebec,Canada,1,45.470556,-73.740833,North America
+JFK,New York,New York,United States,3,40.63980103,-73.77890015,North America
+EWR,Newark,New Jersey,United States,5,40.692501068115234,-74.168701171875,North America
+PAO,Palo Alto,California,United States,1,37.461111,-122.115,North America
+PHL,Philadelphia,Pennsylvania,United States,1,39.87189865112305,-75.24109649658203,North America
+PHX,Phoenix,Arizona,United States,2,33.43429946899414,-112.01200103759766,North America
+SLC,Salt Lake City,Utah,United States,1,40.78839874267578,-111.97799682617188,North America
+SJC,San Jose,California,United States,2,37.362598,-121.929001,North America
+SEA,Seattle,Washington,United States,4,47.448889,-122.309444,North America
+IND,South Bend,Indiana,United States,1,39.7173004,-86.2944031,North America
+YTO,Toronto,Ontario,Canada,2,43.6772003174,-79.63059997559999,North America
+AMS,Amsterdam,,The Netherlands,2,52.308601,4.76389,Europe
+TXL,Berlin,,Germany,2,52.559722,13.287778,Europe
+CPH,Copenhagen,,Denmark,1,55.617900848389,12.656000137329,Europe
+DUB,Dublin,,Ireland,1,53.421299,-6.27007,Europe
+FRA,Frankfurt am Main,,Germany,8,50.033333,8.570556,Europe
+HEL,Helsinki,,Finland,1,60.317199707031,24.963300704956,Europe
+LIS,Lisbon,,Portugal,1,38.7813,-9.13592,Europe
+LHR,London,,England,9,51.4775,-0.461389,Europe
+MAD,Madrid,,Spain,2,40.471926,-3.56264,Europe
+MAN,Manchester,,England,2,53.35369873046875,-2.2749500274658203,Europe
+MRS,Marseille,,France,1,43.439271922,5.22142410278,Europe
+MXP,Milan,,Italy,1,45.6306,8.72811,Europe
+MUC,Munich,,Germany,2,48.353802,11.7861,Europe
+OSL,Oslo,,Norway,1,60.193901062012,11.100399971008,Europe
+PMO,Palermo,,Italy,1,38.175999,13.091,Europe
+CDG,Paris,,France,5,49.012798,2.55,Europe
+PRG,Prague,,Czech Republic,1,50.1008,14.26,Europe
+ARN,Stockholm,,Sweden,3,59.651901245117,17.918600082397,Europe
+VIE,Vienna,,Austria,1,48.110298156738,16.569700241089,Europe
+WMI,Warsaw,,Poland,1,52.451099,20.6518,Europe
+ZRH,Zurich,,Switzerland,2,47.464699,8.54917,Europe
+BLR,Bangalore,,India,3,13.1979,77.706299,Asia
+MAA,Chennai,,India,2,12.990005493164062,80.16929626464844,Asia
+HKG,Hong Kong,,China,3,22.308901,113.915001,Asia
+HYD,Hyderabad,,India,4,17.2313175201,78.4298553467,Asia
+KUL,Kuala Lumpur,,Malaysia,1,2.745579957962,101.70999908447,Asia
+BOM,Mumbai,,India,2,19.0886993408,72.8678970337,Asia
+MNL,Manila,,Philippines,1,14.5086,121.019997,Asia
+DEL,New Delhi,,India,5,28.5665,77.103104,Asia
+KIX,Osaka,,Japan,1,34.42729949951172,135.24400329589844,Asia
+ICN,Seoul,,South Korea,4,37.46910095214844,126.45099639892578,Asia
+SIN,Singapore,,Singapore,3,1.35019,103.994003,Asia
+TPE,Taipei,,Taiwan,3,25.0777,121.233002,Asia
+NRT,Tokyo,,Japan,12,35.7647018433,140.386001587,Asia
+MEL,Melbourne,,Australia,1,-37.673302,144.843002,Australia
+PER,Perth,,Australia,1,-31.94029998779297,115.96700286865234,Australia
+SYD,Sydney,,Australia,2,-33.94609832763672,151.177001953125,Australia
+GRU,Sao Paulo,,Brazil,2,-23.435556,-46.473056,South America
+GIG,Rio de Janeiro,,Brazil,3,-22.8099994659,-43.2505569458,South America
+DXB,Dubai,,United Arab Emirates,1,25.2527999878,55.3643989563,Middle East
+FJR,Fujairah,,United Arab Emirates,1,25.112222,56.324167,Middle East
+BAH,Manama,,Bahrain,1,26.27079963684082,50.63359832763672,Middle East
+TLV,Tel Aviv,,Israel,1,32.01139831542969,34.88669967651367,Middle East
+JNB,Johannesburg,,South Africa,1,-26.1392,28.246,Africa
+CPT,Cape Town,,South Africa,1,-33.9648017883,18.6016998291,Africa
+PEK,Beijing,,China,1,40.080101013183594,116.58499908447266,China
+SZX,Shenzhen,,China,1,22.639299392700195,113.81099700927734,China
+PVG,Shanghai,,China,1,31.143400192260742,121.80500030517578,China
+ZHY,Zhongwei,,China,1,37.572778,105.154444,China

--- a/dist/edge-locations.json
+++ b/dist/edge-locations.json
@@ -5,7 +5,8 @@
     "country": "United States",
     "count": 6,
     "latitude": 38.9445,
-    "longitude": -77.4558029
+    "longitude": -77.4558029,
+    "region": "North America"
   },
   "ATL": {
     "city": "Atlanta",
@@ -13,7 +14,8 @@
     "country": "United States",
     "count": 5,
     "latitude": 33.6367,
-    "longitude": -84.428101
+    "longitude": -84.428101,
+    "region": "North America"
   },
   "BOS": {
     "city": "Boston",
@@ -21,7 +23,8 @@
     "country": "United States",
     "count": 3,
     "latitude": 42.36429977,
-    "longitude": -71.00520325
+    "longitude": -71.00520325,
+    "region": "North America"
   },
   "ORD": {
     "city": "Chicago",
@@ -29,7 +32,8 @@
     "country": "United States",
     "count": 7,
     "latitude": 41.978611,
-    "longitude": -87.904722
+    "longitude": -87.904722,
+    "region": "North America"
   },
   "DFW": {
     "city": "Dallas/Fort Worth",
@@ -37,7 +41,8 @@
     "country": "United States",
     "count": 6,
     "latitude": 32.896801,
-    "longitude": -97.038002
+    "longitude": -97.038002,
+    "region": "North America"
   },
   "DEN": {
     "city": "Denver",
@@ -45,7 +50,8 @@
     "country": "United States",
     "count": 2,
     "latitude": 39.861698150635,
-    "longitude": -104.672996521
+    "longitude": -104.672996521,
+    "region": "North America"
   },
   "HWD": {
     "city": "Hayward",
@@ -53,7 +59,8 @@
     "country": "United States",
     "count": 1,
     "latitude": 37.658889,
-    "longitude": -122.121667
+    "longitude": -122.121667,
+    "region": "North America"
   },
   "HIO": {
     "city": "Hillsboro",
@@ -61,7 +68,8 @@
     "country": "United States",
     "count": 2,
     "latitude": 45.540394,
-    "longitude": -122.949825
+    "longitude": -122.949825,
+    "region": "North America"
   },
   "HOU": {
     "city": "Houston",
@@ -69,7 +77,8 @@
     "country": "United States",
     "count": 4,
     "latitude": 29.64539909,
-    "longitude": -95.27890015
+    "longitude": -95.27890015,
+    "region": "North America"
   },
   "JAX": {
     "city": "Jacksonville",
@@ -77,7 +86,8 @@
     "country": "United States",
     "count": 1,
     "latitude": 30.49410057067871,
-    "longitude": -81.68789672851562
+    "longitude": -81.68789672851562,
+    "region": "North America"
   },
   "LAX": {
     "city": "Los Angeles",
@@ -85,7 +95,8 @@
     "country": "United States",
     "count": 5,
     "latitude": 33.94250107,
-    "longitude": -118.4079971
+    "longitude": -118.4079971,
+    "region": "North America"
   },
   "MIA": {
     "city": "Miami",
@@ -93,7 +104,8 @@
     "country": "United States",
     "count": 3,
     "latitude": 25.79319953918457,
-    "longitude": -80.29060363769531
+    "longitude": -80.29060363769531,
+    "region": "North America"
   },
   "MSP": {
     "city": "Minneapolis",
@@ -101,7 +113,8 @@
     "country": "United States",
     "count": 1,
     "latitude": 44.882,
-    "longitude": -93.221802
+    "longitude": -93.221802,
+    "region": "North America"
   },
   "YUL": {
     "city": "Montreal",
@@ -109,7 +122,8 @@
     "country": "Canada",
     "count": 1,
     "latitude": 45.470556,
-    "longitude": -73.740833
+    "longitude": -73.740833,
+    "region": "North America"
   },
   "JFK": {
     "city": "New York",
@@ -117,7 +131,8 @@
     "country": "United States",
     "count": 3,
     "latitude": 40.63980103,
-    "longitude": -73.77890015
+    "longitude": -73.77890015,
+    "region": "North America"
   },
   "EWR": {
     "city": "Newark",
@@ -125,7 +140,8 @@
     "country": "United States",
     "count": 5,
     "latitude": 40.692501068115234,
-    "longitude": -74.168701171875
+    "longitude": -74.168701171875,
+    "region": "North America"
   },
   "PAO": {
     "city": "Palo Alto",
@@ -133,7 +149,8 @@
     "country": "United States",
     "count": 1,
     "latitude": 37.461111,
-    "longitude": -122.115
+    "longitude": -122.115,
+    "region": "North America"
   },
   "PHL": {
     "city": "Philadelphia",
@@ -141,7 +158,8 @@
     "country": "United States",
     "count": 1,
     "latitude": 39.87189865112305,
-    "longitude": -75.24109649658203
+    "longitude": -75.24109649658203,
+    "region": "North America"
   },
   "PHX": {
     "city": "Phoenix",
@@ -149,7 +167,8 @@
     "country": "United States",
     "count": 2,
     "latitude": 33.43429946899414,
-    "longitude": -112.01200103759766
+    "longitude": -112.01200103759766,
+    "region": "North America"
   },
   "SLC": {
     "city": "Salt Lake City",
@@ -157,7 +176,8 @@
     "country": "United States",
     "count": 1,
     "latitude": 40.78839874267578,
-    "longitude": -111.97799682617188
+    "longitude": -111.97799682617188,
+    "region": "North America"
   },
   "SJC": {
     "city": "San Jose",
@@ -165,7 +185,8 @@
     "country": "United States",
     "count": 2,
     "latitude": 37.362598,
-    "longitude": -121.929001
+    "longitude": -121.929001,
+    "region": "North America"
   },
   "SEA": {
     "city": "Seattle",
@@ -173,7 +194,8 @@
     "country": "United States",
     "count": 4,
     "latitude": 47.448889,
-    "longitude": -122.309444
+    "longitude": -122.309444,
+    "region": "North America"
   },
   "IND": {
     "city": "South Bend",
@@ -181,7 +203,8 @@
     "country": "United States",
     "count": 1,
     "latitude": 39.7173004,
-    "longitude": -86.2944031
+    "longitude": -86.2944031,
+    "region": "North America"
   },
   "YTO": {
     "city": "Toronto",
@@ -189,349 +212,399 @@
     "country": "Canada",
     "count": 2,
     "latitude": 43.6772003174,
-    "longitude": -79.63059997559999
+    "longitude": -79.63059997559999,
+    "region": "North America"
   },
   "AMS": {
     "city": "Amsterdam",
     "country": "The Netherlands",
     "count": 2,
     "latitude": 52.308601,
-    "longitude": 4.76389
+    "longitude": 4.76389,
+    "region": "Europe"
   },
   "TXL": {
     "city": "Berlin",
     "country": "Germany",
     "count": 2,
     "latitude": 52.559722,
-    "longitude": 13.287778
+    "longitude": 13.287778,
+    "region": "Europe"
   },
   "CPH": {
     "city": "Copenhagen",
     "country": "Denmark",
     "count": 1,
     "latitude": 55.617900848389,
-    "longitude": 12.656000137329
+    "longitude": 12.656000137329,
+    "region": "Europe"
   },
   "DUB": {
     "city": "Dublin",
     "country": "Ireland",
     "count": 1,
     "latitude": 53.421299,
-    "longitude": -6.27007
+    "longitude": -6.27007,
+    "region": "Europe"
   },
   "FRA": {
     "city": "Frankfurt am Main",
     "country": "Germany",
     "count": 8,
     "latitude": 50.033333,
-    "longitude": 8.570556
+    "longitude": 8.570556,
+    "region": "Europe"
   },
   "HEL": {
     "city": "Helsinki",
     "country": "Finland",
     "count": 1,
     "latitude": 60.317199707031,
-    "longitude": 24.963300704956
+    "longitude": 24.963300704956,
+    "region": "Europe"
   },
   "LIS": {
     "city": "Lisbon",
     "country": "Portugal",
     "count": 1,
     "latitude": 38.7813,
-    "longitude": -9.13592
+    "longitude": -9.13592,
+    "region": "Europe"
   },
   "LHR": {
     "city": "London",
     "country": "England",
     "count": 9,
     "latitude": 51.4775,
-    "longitude": -0.461389
+    "longitude": -0.461389,
+    "region": "Europe"
   },
   "MAD": {
     "city": "Madrid",
     "country": "Spain",
     "count": 2,
     "latitude": 40.471926,
-    "longitude": -3.56264
+    "longitude": -3.56264,
+    "region": "Europe"
   },
   "MAN": {
     "city": "Manchester",
     "country": "England",
     "count": 2,
     "latitude": 53.35369873046875,
-    "longitude": -2.2749500274658203
+    "longitude": -2.2749500274658203,
+    "region": "Europe"
   },
   "MRS": {
     "city": "Marseille",
     "country": "France",
     "count": 1,
     "latitude": 43.439271922,
-    "longitude": 5.22142410278
+    "longitude": 5.22142410278,
+    "region": "Europe"
   },
   "MXP": {
     "city": "Milan",
     "country": "Italy",
     "count": 1,
     "latitude": 45.6306,
-    "longitude": 8.72811
+    "longitude": 8.72811,
+    "region": "Europe"
   },
   "MUC": {
     "city": "Munich",
     "country": "Germany",
     "count": 2,
     "latitude": 48.353802,
-    "longitude": 11.7861
+    "longitude": 11.7861,
+    "region": "Europe"
   },
   "OSL": {
     "city": "Oslo",
     "country": "Norway",
     "count": 1,
     "latitude": 60.193901062012,
-    "longitude": 11.100399971008
+    "longitude": 11.100399971008,
+    "region": "Europe"
   },
   "PMO": {
     "city": "Palermo",
     "country": "Italy",
     "count": 1,
     "latitude": 38.175999,
-    "longitude": 13.091
+    "longitude": 13.091,
+    "region": "Europe"
   },
   "CDG": {
     "city": "Paris",
     "country": "France",
     "count": 5,
     "latitude": 49.012798,
-    "longitude": 2.55
+    "longitude": 2.55,
+    "region": "Europe"
   },
   "PRG": {
     "city": "Prague",
     "country": "Czech Republic",
     "count": 1,
     "latitude": 50.1008,
-    "longitude": 14.26
+    "longitude": 14.26,
+    "region": "Europe"
   },
   "ARN": {
     "city": "Stockholm",
     "country": "Sweden",
     "count": 3,
     "latitude": 59.651901245117,
-    "longitude": 17.918600082397
+    "longitude": 17.918600082397,
+    "region": "Europe"
   },
   "VIE": {
     "city": "Vienna",
     "country": "Austria",
     "count": 1,
     "latitude": 48.110298156738,
-    "longitude": 16.569700241089
+    "longitude": 16.569700241089,
+    "region": "Europe"
   },
   "WMI": {
     "city": "Warsaw",
     "country": "Poland",
     "count": 1,
     "latitude": 52.451099,
-    "longitude": 20.6518
+    "longitude": 20.6518,
+    "region": "Europe"
   },
   "ZRH": {
     "city": "Zurich",
     "country": "Switzerland",
     "count": 2,
     "latitude": 47.464699,
-    "longitude": 8.54917
+    "longitude": 8.54917,
+    "region": "Europe"
   },
   "BLR": {
     "city": "Bangalore",
     "country": "India",
     "count": 3,
     "latitude": 13.1979,
-    "longitude": 77.706299
+    "longitude": 77.706299,
+    "region": "Asia"
   },
   "MAA": {
     "city": "Chennai",
     "country": "India",
     "count": 2,
     "latitude": 12.990005493164062,
-    "longitude": 80.16929626464844
+    "longitude": 80.16929626464844,
+    "region": "Asia"
   },
   "HKG": {
     "city": "Hong Kong",
     "country": "China",
     "count": 3,
     "latitude": 22.308901,
-    "longitude": 113.915001
+    "longitude": 113.915001,
+    "region": "Asia"
   },
   "HYD": {
     "city": "Hyderabad",
     "country": "India",
     "count": 4,
     "latitude": 17.2313175201,
-    "longitude": 78.4298553467
+    "longitude": 78.4298553467,
+    "region": "Asia"
   },
   "KUL": {
     "city": "Kuala Lumpur",
     "country": "Malaysia",
     "count": 1,
     "latitude": 2.745579957962,
-    "longitude": 101.70999908447
+    "longitude": 101.70999908447,
+    "region": "Asia"
   },
   "BOM": {
     "city": "Mumbai",
     "country": "India",
     "count": 2,
     "latitude": 19.0886993408,
-    "longitude": 72.8678970337
+    "longitude": 72.8678970337,
+    "region": "Asia"
   },
   "MNL": {
     "city": "Manila",
     "country": "Philippines",
     "count": 1,
     "latitude": 14.5086,
-    "longitude": 121.019997
+    "longitude": 121.019997,
+    "region": "Asia"
   },
   "DEL": {
     "city": "New Delhi",
     "country": "India",
     "count": 5,
     "latitude": 28.5665,
-    "longitude": 77.103104
+    "longitude": 77.103104,
+    "region": "Asia"
   },
   "KIX": {
     "city": "Osaka",
     "country": "Japan",
     "count": 1,
     "latitude": 34.42729949951172,
-    "longitude": 135.24400329589844
+    "longitude": 135.24400329589844,
+    "region": "Asia"
   },
   "ICN": {
     "city": "Seoul",
     "country": "South Korea",
     "count": 4,
     "latitude": 37.46910095214844,
-    "longitude": 126.45099639892578
+    "longitude": 126.45099639892578,
+    "region": "Asia"
   },
   "SIN": {
     "city": "Singapore",
     "country": "Singapore",
     "count": 3,
     "latitude": 1.35019,
-    "longitude": 103.994003
+    "longitude": 103.994003,
+    "region": "Asia"
   },
   "TPE": {
     "city": "Taipei",
     "country": "Taiwan",
     "count": 3,
     "latitude": 25.0777,
-    "longitude": 121.233002
+    "longitude": 121.233002,
+    "region": "Asia"
   },
   "NRT": {
     "city": "Tokyo",
     "country": "Japan",
     "count": 12,
     "latitude": 35.7647018433,
-    "longitude": 140.386001587
+    "longitude": 140.386001587,
+    "region": "Asia"
   },
   "MEL": {
     "city": "Melbourne",
     "country": "Australia",
     "count": 1,
     "latitude": -37.673302,
-    "longitude": 144.843002
+    "longitude": 144.843002,
+    "region": "Australia"
   },
   "PER": {
     "city": "Perth",
     "country": "Australia",
     "count": 1,
     "latitude": -31.94029998779297,
-    "longitude": 115.96700286865234
+    "longitude": 115.96700286865234,
+    "region": "Australia"
   },
   "SYD": {
     "city": "Sydney",
     "country": "Australia",
     "count": 2,
     "latitude": -33.94609832763672,
-    "longitude": 151.177001953125
+    "longitude": 151.177001953125,
+    "region": "Australia"
   },
   "GRU": {
     "city": "Sao Paulo",
     "country": "Brazil",
     "count": 2,
     "latitude": -23.435556,
-    "longitude": -46.473056
+    "longitude": -46.473056,
+    "region": "South America"
   },
   "GIG": {
     "city": "Rio de Janeiro",
     "country": "Brazil",
     "count": 3,
     "latitude": -22.8099994659,
-    "longitude": -43.2505569458
+    "longitude": -43.2505569458,
+    "region": "South America"
   },
   "DXB": {
     "city": "Dubai",
     "country": "United Arab Emirates",
     "count": 1,
     "latitude": 25.2527999878,
-    "longitude": 55.3643989563
+    "longitude": 55.3643989563,
+    "region": "Middle East"
   },
   "FJR": {
     "city": "Fujairah",
     "country": "United Arab Emirates",
     "count": 1,
     "latitude": 25.112222,
-    "longitude": 56.324167
+    "longitude": 56.324167,
+    "region": "Middle East"
   },
   "BAH": {
     "city": "Manama",
     "country": "Bahrain",
     "count": 1,
     "latitude": 26.27079963684082,
-    "longitude": 50.63359832763672
+    "longitude": 50.63359832763672,
+    "region": "Middle East"
   },
   "TLV": {
     "city": "Tel Aviv",
     "country": "Israel",
     "count": 1,
     "latitude": 32.01139831542969,
-    "longitude": 34.88669967651367
+    "longitude": 34.88669967651367,
+    "region": "Middle East"
   },
   "JNB": {
     "city": "Johannesburg",
     "country": "South Africa",
     "count": 1,
     "latitude": -26.1392,
-    "longitude": 28.246
+    "longitude": 28.246,
+    "region": "Africa"
   },
   "CPT": {
     "city": "Cape Town",
     "country": "South Africa",
     "count": 1,
     "latitude": -33.9648017883,
-    "longitude": 18.6016998291
+    "longitude": 18.6016998291,
+    "region": "Africa"
   },
   "PEK": {
     "city": "Beijing",
     "country": "China",
     "count": 1,
     "latitude": 40.080101013183594,
-    "longitude": 116.58499908447266
+    "longitude": 116.58499908447266,
+    "region": "China"
   },
   "SZX": {
     "city": "Shenzhen",
     "country": "China",
     "count": 1,
     "latitude": 22.639299392700195,
-    "longitude": 113.81099700927734
+    "longitude": 113.81099700927734,
+    "region": "China"
   },
   "PVG": {
     "city": "Shanghai",
     "country": "China",
     "count": 1,
     "latitude": 31.143400192260742,
-    "longitude": 121.80500030517578
+    "longitude": 121.80500030517578,
+    "region": "China"
   },
   "ZHY": {
     "city": "Zhongwei",
     "country": "China",
     "count": 1,
     "latitude": 37.572778,
-    "longitude": 105.154444
+    "longitude": 105.154444,
+    "region": "China"
   }
 }

--- a/generate.js
+++ b/generate.js
@@ -88,9 +88,9 @@ const airportOverridesData = {
 
 const writeCSV = locations => {
     const csvPath = path.join(__dirname, 'dist', 'edge-locations.csv');
-    const data = locations.map(e => { return `${e.code},${e.city},${e.state || ''},${e.country},${e.count},${e.latitude},${e.longitude}` });
+    const data = locations.map(e => { return `${e.code},${e.city},${e.state || ''},${e.country},${e.count},${e.latitude},${e.longitude},${e.region}` });
     // Add header
-    data.unshift('code,city,state,country,count,latitude,longitude');
+    data.unshift('code,city,state,country,count,latitude,longitude,region');
     fs.writeFileSync(csvPath, data.join(os.EOL), 'utf8');
 }
 
@@ -104,7 +104,8 @@ const writeJSON = locations => {
             country: location.country,
             count: location.count,
             latitude: location.latitude,
-            longitude: location.longitude
+            longitude: location.longitude,
+            region: location.region
         }
     });
     fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2), 'utf8');
@@ -158,7 +159,12 @@ const createLocation = location => {
     } else {
         locationObj.count = 1;
         locationObj.country = temp[1].trim();
-    }    
+    }
+
+    // region is the third detail in string
+    locationObj.region = temp[2].trim();
+
+    // region
     return locationObj;
 }
 
@@ -170,7 +176,6 @@ const run = async () => {
     await page.goto('https://aws.amazon.com/cloudfront/features/?nc1=h_ls')
 
     const data = await page.evaluate(() => {
-
         const result = [];
         // Selector
         const rawLocations = document.evaluate('//*[@id="aws-page-content"]/main/div[1]/div/div/div[@class="lb-rtxt"]/p[*]', document);
@@ -187,6 +192,27 @@ const run = async () => {
         // Remove first and last item
         result.shift();
         result.pop();
+
+        /**
+         * @desc get an array witth regions names, this will be used to group
+         * related locations by region (≠ continent). Regions are extracted
+         * from each set title element, wich ATM is the previous sibling of the
+         * $locationsSets
+         * @returns {Array} - ["North America", "Europe", "Asia", ...]
+         */
+        const extractRegions = () => {
+            const $contentContainer = document
+                .getElementById('Amazon_CloudFront_Infrastructure')
+                .parentElement;
+            const $locationsSets = Array.from($contentContainer.querySelectorAll('.lb-rtxt'))
+                .slice(1, -1); // false positives first and last matches
+            // return only cleaned text string
+            return $locationsSets.map(set => 
+                set.previousElementSibling.textContent.trim()
+            );
+        }
+
+        const regions = extractRegions();
 
         let locations = [];
         let caches = [];
@@ -255,11 +281,18 @@ const run = async () => {
         edgeLocations[7] = `${chinaFix}, China`;
 
         // Generate edge location array
-        edgeLocations.forEach(locationList => {
-            const details = locationList.split('; ');
+        // [0] get each region location set string
+        // [1] append region to each location details string
+        // @todo [0] - I don't think it ever enters here, since split 
+        //  of a string is always an Array?
+        edgeLocations.forEach((locationList, index) => {
+            const details = locationList
+                .split('; ') // [0]
+                .map(l => l.concat(`, ${regions[index]}`)); // [1]
+
             if (Array.isArray(details)) {
                 locations = locations.concat(details);
-            } else {
+            } else { // @todo [0]            
                 locations.push(locationList);
             }
         });

--- a/test/tests.js
+++ b/test/tests.js
@@ -20,7 +20,8 @@ describe("# Testing the aws-edge-locations functionality", function() {
                 "country": "United States",
                 "count": 6,
                 "latitude": 38.9445,
-                "longitude": -77.4558029
+                "longitude": -77.4558029,
+                "region": "North America"
             });
             done();
 


### PR DESCRIPTION
Includes region field (grouping used by aws, slightly different than continent) in the datasets

- Extracts "regions", from each pop location [set title on aws site](https://aws.amazon.com/cloudfront/features/)
- Append corresponding region to each location object, thus extending the dataset.